### PR TITLE
chore: remove obsolete replacements from synth.py

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -40,16 +40,6 @@ common_templates = gcp.CommonTemplates()
 templates = common_templates.node_library(source_location='build/src')
 s.copy(templates)
 
-# [START fix-dead-link]
-s.replace('**/doc/google/protobuf/doc_timestamp.js',
-        'https:\/\/cloud\.google\.com[\s\*]*http:\/\/(.*)[\s\*]*\)',
-        r"https://\1)")
-
-s.replace('**/doc/google/protobuf/doc_timestamp.js',
-        'toISOString\]',
-        'toISOString)')
-# [END fix-dead-link]
-
 # Node.js specific cleanup
 subprocess.run(['npm', 'install'])
 subprocess.run(['npm', 'run', 'fix'])


### PR DESCRIPTION
```
2020-03-05 14:36:59,366 synthtool > No replacements made in **/doc/google/protobuf/doc_timestamp.js for pattern https:\/\/cloud\.google\.com[\s\*]*http:\/\/(.*)[\s\*]*\), maybe replacement is no longer needed?
2020-03-05 14:36:59,378 synthtool > No replacements made in **/doc/google/protobuf/doc_timestamp.js for pattern toISOString\], maybe replacement is no longer needed?
```
