### PR TITLE
test: run system and sample tests with cloud build

### DIFF
--- a/.github/cloudbuild.samples.yaml
+++ b/.github/cloudbuild.samples.yaml
@@ -1,0 +1,7 @@
+steps:
+- name: node:14
+  entrypoint: npm
+  args: ['install', '--unsafe-perm']
+- name: node:14
+  entrypoint: npm
+  args: ['run', 'samples-test']

--- a/.github/cloudbuild.system.yaml
+++ b/.github/cloudbuild.system.yaml
@@ -1,0 +1,7 @@
+steps:
+- name: node:14
+  entrypoint: npm
+  args: ['install', '--unsafe-perm']
+- name: node:14
+  entrypoint: npm
+  args: ['run', 'system-test']

--- a/samples/test/test.samples.js
+++ b/samples/test/test.samples.js
@@ -14,21 +14,26 @@
 
 'use strict';
 
+const {CloudSchedulerClient} = require('@google-cloud/scheduler');
 const {assert} = require('chai');
-const {describe, it} = require('mocha');
+const {describe, it, before} = require('mocha');
 const cp = require('child_process');
 const supertest = require('supertest');
 const app = require('../app.js');
 const request = supertest(app);
 
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
-
-const PROJECT_ID = process.env.GCLOUD_PROJECT;
 const LOCATION_ID = process.env.LOCATION_ID || 'us-central1';
 const SERVICE_ID = 'my-service';
 
 describe('Cloud Scheduler Sample Tests', () => {
   let jobName;
+  let PROJECT_ID;
+
+  before(async () => {
+    const client = new CloudSchedulerClient();
+    PROJECT_ID = await client.getProjectId();
+  });
 
   it('should create and delete a scheduler job', async () => {
     const stdout = execSync(


### PR DESCRIPTION
This is an experiment.  I would like to land this PR, and then try setting up triggers to run the system and sample tests with Cloud Build instead of Kokoro.  The manual steps involved here so far would include:
- Creating the trigger
- Adding the neccessary permissions to the Cloud Builder Service Account.

@donmccasland that second one is ... unfortunate.  Can you verify that you cannot use a custom service account along with GitHub based triggers with Cloud build?